### PR TITLE
Add JaCoCo plugin and configure GitHub Actions

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -40,4 +40,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Run unit tests
-        run: ./gradlew test
+        run: ./gradlew clean jacocoRootReport --no-daemon
+
+      - name: Upload JaCoCo HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-html-report
+          path: build/reports/jacoco/jacocoRootReport/html

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew clean jacocoRootReport --no-daemon
 
       - name: Upload JaCoCo HTML report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
           path: build/reports/jacoco/jacocoRootReport/html

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -47,3 +47,9 @@ jobs:
         with:
           name: jacoco-html-report
           path: build/reports/jacoco/jacocoRootReport/html
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v2
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,69 @@ plugins {
     alias(libs.plugins.hilt.plugin) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ksp.plugin) apply false
+
+    id("jacoco")
+}
+
+tasks.register<JacocoReport>("jacocoRootReport") {
+    group = "verification"
+    description = "Genera reporte JaCoCo combinado de todos los módulos"
+
+    // 1- Dependencies: First run all the local test tasks
+    dependsOn(
+        ":presentation:jacocoPresentationTestReport",
+        ":data:jacocoDataTestReport",
+        ":domain:jacocoDomainTestReport"
+    )
+
+    // 2- Get all the .exec files from all modules
+    executionData.setFrom(
+        files(
+            "presentation/build/jacoco/testDebugUnitTest.exec",
+            "data/build/jacoco/testDebugUnitTest.exec",
+            "domain/build/jacoco/test.exec"
+        )
+    )
+
+    // 3- Directories with the compiled classes (excluding auto-generated files)
+    classDirectories.setFrom(
+        files(
+            fileTree("presentation/build/tmp/kotlin-classes/debug") {
+                exclude(
+                    "**/R.class",
+                    "**/R$*.class",
+                    "**/BuildConfig.*",
+                    "**/*Test*.*"
+                )
+            },
+            fileTree("data/build/tmp/kotlin-classes/debug") {
+                exclude(
+                    "**/R.class",
+                    "**/R$*.class",
+                    "**/BuildConfig.*",
+                    "**/*Test*.*"
+                )
+            },
+            fileTree("domain/build/classes/kotlin/main") {
+                exclude("**/*Test*.*")
+            }
+        )
+    )
+
+    // 4- Source code directories
+    sourceDirectories.setFrom(
+        files(
+            "presentation/src/main/kotlin",
+            "data/src/main/kotlin",
+            "domain/src/main/kotlin"
+        )
+    )
+
+    // 5- Reports configuration
+    reports {
+        html.required.set(true)
+        html.outputLocation.set(layout.buildDirectory.dir("reports/jacoco/jacocoRootReport/html"))
+        xml.required.set(true)
+        xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacocoRootReport/report.xml"))
+    }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -4,6 +4,47 @@ plugins {
     alias(libs.plugins.ksp.plugin)
     alias(libs.plugins.hilt.plugin)
     alias(libs.plugins.kotlin.serialization) // Needed to use the Json serialization in Retrofit
+    id("jacoco")
+}
+
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.register<JacocoReport>("jacocoDataTestReport") {
+
+    dependsOn("testDebugUnitTest") // Dependency: First execute unit tests
+
+    group = "verification"
+    description = "Generates JaCoCo report for the unit tests of the Data module"
+
+    reports {
+        xml.required.set(true)    // Needed for CI/SonarCloud integrations
+        html.required.set(true)   // Required for local visualization
+        csv.required.set(false)
+    }
+
+    // Exclude auto-generated files by the Android build process
+    val excludes = listOf(
+        "**/R.class",
+        "**/R$*.class",
+        "**/BuildConfig.*",
+        "**/Manifest*.*",
+        "**/*Test*.*"
+    )
+
+    // Directories with the compiled classes
+    val kotlinClasses = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug").get().asFile) {
+        exclude(excludes)
+    }
+
+    classDirectories.setFrom(files(kotlinClasses))
+    sourceDirectories.setFrom(files("src/main/kotlin"))
+    executionData.setFrom(
+        fileTree(layout.buildDirectory.asFile).include(
+            "jacoco/testDebugUnitTest.exec"
+        )
+    )
 }
 
 android {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,7 +1,34 @@
 plugins {
     `java-library`
     kotlin("jvm")
+    id("jacoco")
 }
+
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.register<JacocoReport>("jacocoDomainTestReport") {
+    dependsOn("test") // Dependency: First execute unit tests
+
+    group = "verification"
+    description = "Generates JaCoCo report for the unit tests of the Domain module"
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(false)
+    }
+
+    val kotlinClasses = fileTree(layout.buildDirectory.dir("classes/kotlin/main").get().asFile) {
+        exclude("**/*Test*.*")
+    }
+
+    classDirectories.setFrom(files(kotlinClasses))
+    sourceDirectories.setFrom(files("src/main/kotlin"))
+    executionData.setFrom(fileTree(layout.buildDirectory.asFile).include("jacoco/test.exec"))
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -5,6 +5,43 @@ plugins {
     alias(libs.plugins.ksp.plugin)
     alias(libs.plugins.hilt.plugin)
     alias(libs.plugins.compose.compiler)
+    id("jacoco")
+}
+
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.register<JacocoReport>("jacocoPresentationTestReport") {
+
+    dependsOn("testDebugUnitTest") // Dependency: First execute unit tests
+
+    group = "verification"
+    description = "Generates JaCoCo report for the unit tests of the Presentation module"
+
+    reports {
+        xml.required.set(true)    // Needed for CI/SonarCloud integrations
+        html.required.set(true)   // Required for local visualization
+        csv.required.set(false)
+    }
+
+    // Excluded files
+    val excludes = listOf(
+        "**/R.class",
+        "**/R$*.class",
+        "**/BuildConfig.*",
+        "**/Manifest*.*",
+        "**/*Test*.*"
+    )
+
+    // Directories with the compiled classes
+    val kotlinClasses = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug").get().asFile) {
+        exclude(excludes)
+    }
+
+    classDirectories.setFrom(files(kotlinClasses))
+    sourceDirectories.setFrom(files("src/main/kotlin"))
+    executionData.setFrom(fileTree(layout.buildDirectory.asFile).include("jacoco/testDebugUnitTest.exec"))
 }
 
 android {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,11 +4,11 @@ sonar.projectKey=StarWarsApp
 sonar.host.url=https://sonarcloud.io
 
 # Folders with source code and tests
-sonar.sources=src/main/kotlin
-sonar.tests=src/test/kotlin
+sonar.sources=presentation/src/main/kotlin,domain/src/main/kotlin,data/src/main/kotlin
+sonar.tests=presentation/src/test/kotlin,domain/src/test/kotlin,data/src/test/kotlin
 
 # Route to JaCoCo XML
-sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/jacocoRootReport/report.xml
+sonar.coverage.jacoco.xmlReportPaths=presentation/build/reports/jacoco/test/report.xml,domain/build/reports/jacoco/test/report.xml,data/build/reports/jacoco/test/report.xml
 
 # Wait for the Quality Gate result and fail if not met
 sonar.qualitygate.wait=true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 # Identification of the project in SonarCloud
 sonar.organization=javiervav
-sonar.projectKey=StarWarsApp
+sonar.projectKey=javiervav_StarWarsApp
 sonar.host.url=https://sonarcloud.io
 
 # Folders with source code and tests

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+# Identification of the project in SonarCloud
+sonar.organization=javiervav
+sonar.projectKey=StarWarsApp
+sonar.host.url=https://sonarcloud.io
+
+# Folders with source code and tests
+sonar.sources=src/main/kotlin
+sonar.tests=src/test/kotlin
+
+# Route to JaCoCo XML
+sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/jacocoRootReport/report.xml
+
+# Wait for the Quality Gate result and fail if not met
+sonar.qualitygate.wait=true
+sonar.qualitygate.timeout=600


### PR DESCRIPTION
## Notes

<!-- Add any notes here -->

- Add and configure JaCoCo plugin to get code coverage reports in the three modules.
- Update GitHub Actions to upload the generated code coverage report.
- Configure SonarQube.


## Link to Trello ticket

<!-- Please provide a link to the Trello ticket associated with this pull request. -->

[Trello ticket](https://trello.com/c/uL0tjw50)


## Change type

<!-- Put an `x` in the boxes that apply -->

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [x] Other